### PR TITLE
Improved the Dockerfile and added kubernetes examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,23 @@
-FROM centos:7
+FROM golang:1.9.2
+
+RUN mkdir /src
+COPY *.go /src/
+RUN go get -u "github.com/prometheus/client_golang/prometheus"
+RUN go get -u "github.com/prometheus/client_golang/prometheus/promhttp"
+RUN go get -u "github.com/prometheus/common/log"
+RUN go get -u "github.com/prometheus/common/version"
+RUN go get -u "github.com/heketi/heketi/client/api/go-client"
+RUN go get -u "github.com/heketi/heketi/pkg/glusterfs/api"
+
+WORKDIR /src
+ENV CGO_ENABLED=0
+RUN go build -o heketi-metrics-exporter
+
+FROM scratch
 LABEL authors="Robert Tindell <Robert@Tindell.info>, CSC Rahti Team <rahti-team@postit.csc.fi>"
-
 EXPOSE 9189
-
 # Copy heketi_exporter
-COPY heketi-metrics-exporter /usr/bin/heketi-metrics-exporter
+COPY --from=0 /src/heketi-metrics-exporter /heketi-metrics-exporter
 
-CMD /usr/bin/heketi-metrics-exporter
+CMD ["/heketi-metrics-exporter"]
+ENTRYPOINT ["/heketi-metrics-exporter"]

--- a/examples/kubernetes/deployment.yaml
+++ b/examples/kubernetes/deployment.yaml
@@ -1,0 +1,42 @@
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: heketi-exporter
+  labels:
+    glusterfs: heketi-exporter
+    heketi: exporter
+    app: heketi-exporter
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: heketi
+      labels:
+        glusterfs: heketi-exporter
+        heketi: exporter
+        app: heketi-exporter
+    spec:
+      restartPolicy: Always
+      containers:
+        - name: heketi-exporter
+          image: <CHANGE ME>/heketi-metrics-exporter:latest
+          imagePullPolicy: Always
+          command: ["/heketi-metrics-exporter"]
+          env:
+          - name: HEKETI_CLI_USER
+            value: admin
+          - name: HEKETI_CLI_KEY
+            value: "<CHANGE ME>"
+          - name: HEKETI_CLI_SERVER
+            value: "http://<CHANGE ME>:8080"
+          ports:
+            - containerPort: 9189
+              name: scrape
+          resources:
+            requests:
+              cpu: 10m
+              memory: 200Mi
+          terminationMessagePath: /dev/termination-log
+          securityContext:
+            capabilities: {}
+            privileged: false

--- a/examples/kubernetes/service.yaml
+++ b/examples/kubernetes/service.yaml
@@ -1,0 +1,20 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: heketi-exporter
+  labels:
+    glusterfs: heketi-exporter
+    heketi: exporter
+    app: heketi-exporter
+  annotations:
+    prometheus.io/scrape: "true"
+spec:
+  selector:
+    glusterfs: heketi-exporter
+    app: heketi-exporter
+  clusterIP: None
+  ports:
+  - name: scrape
+    port: 9189
+    protocol: TCP
+    targetPort: 9189


### PR DESCRIPTION
Changes : 
- No need to "make" before the docker build
- Image based on scratch instead of centos to reduce image size
- added a kubernetes example